### PR TITLE
Some small changes

### DIFF
--- a/custom_components/ergomotion/core/entity.py
+++ b/custom_components/ergomotion/core/entity.py
@@ -19,13 +19,10 @@ class XEntity(Entity):
             manufacturer=NAME,
             name=device.name or NAME,
         )
-        self._attr_name = device.name + " " + attr.replace("_", " ").title()
-        self._attr_unique_id = device.mac.replace(":", "") + "_" + attr
-
-        self.entity_id = DOMAIN + "." + self._attr_unique_id
+        self._attr_name = f"{device.name} {attr.replace('_', ' ').title()}"
+        self._attr_unique_id = device.mac.replace(":", "").lower() + "_" + attr
 
         self.internal_update()
-
         device.register_update(attr, self.internal_update)
 
     def internal_update(self):

--- a/custom_components/ergomotion/cover.py
+++ b/custom_components/ergomotion/cover.py
@@ -19,14 +19,26 @@ async def async_setup_entry(
 class XCover(XEntity, CoverEntity, RestoreEntity):
     _attr_is_closed = None
 
+    def __init__(self, device, attr):
+        super().__init__(device, attr)
+
+        self._attr_extra_state_attributes = {
+            "max_position": 100
+        }
+
+
     async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+
         state = await self.async_get_last_state()
-        max_position = state.attributes.get("max_position") if state else None
-        self._attr_extra_state_attributes = {"max_position": max_position or 100}
+        if state and "max_position" in state.attributes:
+            self._attr_extra_state_attributes["max_position"] = (
+                state.attributes.get("max_position", 100)
+            )
 
     @property
     def max_position(self):
-        return self._attr_extra_state_attributes["max_position"]
+        return self._attr_extra_state_attributes.get("max_position", 100)
 
     def internal_update(self):
         attribute = self.device.attribute(self.attr)


### PR DESCRIPTION
Fixed entity ID handling and initialization issues:
Fixed race condition by initializing _attr_extra_state_attributes in XCover.__init__ before BLE callbacks.
Moved state restoration logic to async_added_to_hass, avoiding early attribute access errors.